### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ cd ..
     
 git clone https://github.com/fplll/g6k
 cd g6k
+autoreconf -i
+./configure --prefix=$SAGE_LOCAL --disable-static
 make
 pip install -r requirements.txt
 ./rebuild.sh


### PR DESCRIPTION
The current instructions are a little outdated, as G6K doesn't ship with a makefile anymore.
This PR fixes this problem by simply adding ``autoreconf -i`` and ``./configure``.

I copied the existing arguments for configure and it seems to work fine, but this should be double checked by someone else before merging.
